### PR TITLE
Additional data loading options

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The Flow and CARLA tasks also require additional installation steps:
 
 d4rl uses the [OpenAI Gym](https://github.com/openai/gym) API. Tasks are created via the `gym.make` function. A full list of all tasks is [available here](https://github.com/rail-berkeley/d4rl/wiki/Tasks).
 
-Each task is associated with a fixed offline dataset, which can be obtained with the `get_dataset` method. This method returns a dictionary with `observations`, `actions`, `rewards`, `terminals`, and `infos` as keys. 
+Each task is associated with a fixed offline dataset, which can be obtained with the `env.get_dataset()` method. This method returns a dictionary with `observations`, `actions`, `rewards`, `terminals`, and `infos` as keys. You can also load data using `d4rl.qlearning_dataset(env)`, which formats the data for use by typical Q-learning algorithms by adding a `next_observations` key.
 
 ```python
 import gym
@@ -43,11 +43,16 @@ env.reset()
 env.step(env.action_space.sample())
 
 # Each task is associated with a dataset
+# dataset contains observations, actions, rewards, terminals, and infos
 dataset = env.get_dataset()
 print(dataset['observations']) # An N x dim_observation Numpy array of observations
+
+# Alternatively, use d4rl.qlearning_dataset which
+# also adds next_observations.
+dataset = d4rl.qlearning_dataset(env)
 ```
 
-Datasets are automatically downloaded to the `~/.d4rl/datasets` directory. If you would like to change the location of this directory, you can set the `$D4RL_DATASET_DIR` environment variable to the directory of your choosing, or pass in the dataset filepath directly into the `get_dataset` method.
+Datasets are automatically downloaded to the `~/.d4rl/datasets` directory when `get_dataset()` is called. If you would like to change the location of this directory, you can set the `$D4RL_DATASET_DIR` environment variable to the directory of your choosing, or pass in the dataset filepath directly into the `get_dataset` method.
 
 ## Algorithm Implementations
 

--- a/d4rl/__init__.py
+++ b/d4rl/__init__.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import numpy as np
 
 import d4rl.locomotion
 import d4rl.hand_manipulation_suite
@@ -33,3 +34,67 @@ except ImportError as e:
         print(_ERROR_MESSAGE % 'CARLA', file=sys.stderr)
         print(e, file=sys.stderr)
 
+
+def qlearning_dataset(env, dataset=None, terminate_on_end=False, **kwargs):
+    """
+    Returns datasets formatted for use by standard Q-learning algorithms,
+    with observations, actions, next_observations, rewards, and a terminal
+    flag.
+
+    Args:
+        env: An OfflineEnv object.
+        dataset: An optional dataset to pass in for processing. If None,
+            the dataset will default to env.get_dataset()
+        terminate_on_end (bool): Set done=True on the last timestep
+            in a trajectory. Default is False, and will discard the
+            last timestep in each trajectory.
+        **kwargs: Arguments to pass to env.get_dataset().
+
+    Returns:
+        A dictionary containing keys:
+            observations: An N x dim_obs array of observations.
+            actions: An N x dim_action array of actions.
+            next_observations: An N x dim_obs array of next observations.
+            rewards: An N-dim float array of rewards.
+            terminals: An N-dim boolean array of "done" or episode termination flags.
+    """
+    if dataset is None:
+        dataset = env.get_dataset(**kwargs)
+
+    N = dataset['rewards'].shape[0]
+    obs_ = []
+    next_obs_ = []
+    action_ = []
+    reward_ = []
+    done_ = []
+
+    episode_step = 0
+    for i in range(N-1):
+        obs = dataset['observations'][i]
+        new_obs = dataset['observations'][i+1]
+        action = dataset['actions'][i]
+        reward = dataset['rewards'][i]
+        done_bool = bool(dataset['terminals'][i])
+
+        final_timestep = (episode_step == env._max_episode_steps - 1)
+        if (not terminate_on_end) and final_timestep:
+            # Skip this transition and don't apply terminals on the last step of an episode
+            episode_step = 0
+            continue  
+        if done_bool or final_timestep:
+            episode_step = 0
+
+        obs_.append(obs)
+        next_obs_.append(new_obs)
+        action_.append(action)
+        reward_.append(reward)
+        done_.append(done_bool)
+        episode_step += 1
+
+    return {
+        'observations': np.array(obs_),
+        'actions': np.array(action_),
+        'next_observations': np.array(next_obs_),
+        'rewards': np.array(reward_),
+        'terminals': np.array(done_),
+    }

--- a/d4rl/offline_env.py
+++ b/d4rl/offline_env.py
@@ -35,6 +35,7 @@ def download_dataset_from_url(dataset_url):
     return dataset_filepath
 
 
+
 class OfflineEnv(gym.Env):
     """
     Base class for offline RL envs.

--- a/scripts/check_envs.py
+++ b/scripts/check_envs.py
@@ -3,31 +3,9 @@ A quick script to run a sanity check on all environments.
 """
 import gym
 import d4rl
-import d4rl.kitchen
+import numpy as np
 
 ENVS = [
-    'maze2d-open-v0',
-    'maze2d-umaze-v0',
-    'maze2d-medium-v0',
-    'maze2d-large-v0',
-    'maze2d-open-dense-v0',
-    'maze2d-umaze-dense-v0',
-    'maze2d-medium-dense-v0',
-    'maze2d-large-dense-v0',
-    'minigrid-fourrooms-v0',
-    'minigrid-fourrooms-random-v0',
-    'pen-human-v0',
-    'pen-cloned-v0',
-    'pen-expert-v0',
-    'hammer-human-v0',
-    'hammer-cloned-v0',
-    'hammer-expert-v0',
-    'relocate-human-v0',
-    'relocate-cloned-v0',
-    'relocate-expert-v0',
-    'door-human-v0',
-    'door-cloned-v0',
-    'door-expert-v0',
     'halfcheetah-random-v0',
     'halfcheetah-medium-v0',
     'halfcheetah-expert-v0',
@@ -43,6 +21,28 @@ ENVS = [
     'hopper-expert-v0',
     'hopper-mixed-v0',
     'hopper-medium-expert-v0',
+    'maze2d-open-v0',
+    'maze2d-umaze-v1',
+    'maze2d-medium-v1',
+    'maze2d-large-v1',
+    'maze2d-open-dense-v0',
+    'maze2d-umaze-dense-v1',
+    'maze2d-medium-dense-v1',
+    'maze2d-large-dense-v1',
+    'minigrid-fourrooms-v0',
+    'minigrid-fourrooms-random-v0',
+    'pen-human-v0',
+    'pen-cloned-v0',
+    'pen-expert-v0',
+    'hammer-human-v0',
+    'hammer-cloned-v0',
+    'hammer-expert-v0',
+    'relocate-human-v0',
+    'relocate-cloned-v0',
+    'relocate-expert-v0',
+    'door-human-v0',
+    'door-cloned-v0',
+    'door-expert-v0',
     'antmaze-umaze-v0',
     'antmaze-umaze-diverse-v0',
     'antmaze-medium-play-v0',
@@ -57,8 +57,12 @@ ENVS = [
 if __name__ == '__main__':
     for env_name in ENVS:
         print('Checking', env_name)
-        env = gym.make(env_name)
+        try:
+            env = gym.make(env_name)
+        except:
+            continue
         dset = env.get_dataset()
+        print('\t Max episode steps:', env._max_episode_steps)
         print('\t',dset['observations'].shape, dset['actions'].shape)
         assert 'observations' in dset, 'Observations not in dataset'
         assert 'actions' in dset, 'Actions not in dataset'
@@ -69,8 +73,22 @@ if __name__ == '__main__':
         assert dset['actions'].shape[0] == N, 'Action number does not match (%d vs %d)' % (dset['actions'].shape[0], N)
         assert dset['rewards'].shape[0] == N, 'Reward number does not match (%d vs %d)' % (dset['rewards'].shape[0], N)
         assert dset['terminals'].shape[0] == N, 'Terminals number does not match (%d vs %d)' % (dset['terminals'].shape[0], N)
+        print('\t num terminals: %d' % np.sum(dset['terminals']))
 
         env.reset()
         env.step(env.action_space.sample())
         score = env.get_normalized_score(0.0)
 
+        dset = d4rl.qlearning_dataset(env, dataset=dset)
+        assert 'observations' in dset, 'Observations not in dataset'
+        assert 'next_observations' in dset, 'Observations not in dataset'
+        assert 'actions' in dset, 'Actions not in dataset'
+        assert 'rewards' in dset, 'Rewards not in dataset'
+        assert 'terminals' in dset, 'Terminals not in dataset'
+        N = dset['observations'].shape[0]
+        print('\t %d samples' % N)
+        assert dset['next_observations'].shape[0] == N, 'NextObs number does not match (%d vs %d)' % (dset['actions'].shape[0], N)
+        assert dset['actions'].shape[0] == N, 'Action number does not match (%d vs %d)' % (dset['actions'].shape[0], N)
+        assert dset['rewards'].shape[0] == N, 'Reward number does not match (%d vs %d)' % (dset['rewards'].shape[0], N)
+        assert dset['terminals'].shape[0] == N, 'Terminals number does not match (%d vs %d)' % (dset['terminals'].shape[0], N)
+        print('\t num terminals: %d' % np.sum(dset['terminals']))


### PR DESCRIPTION
Adds functionality for loading datasets formatted for Q-learning algorithms. Adds a qlearning_dataset function which 
- Computes next_observations from the dataset.
- Has an option for ignoring the terminal states for episodes that reach the max_path_length. This behavior is set to be the default, and avoids introducing non-markovian behavior into the dataset.