### PR TITLE
Add assets for locomotion and DAPG to package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,4 +13,13 @@ setup(
                       'dm_control @ git+git://github.com/deepmind/dm_control@master#egg=dm_control',
                       'mjrl @ git+git://github.com/aravindr93/mjrl@master#egg=mjrl'],
     packages=find_packages(),
+    package_data={'d4rl': ['locomotion/assets/*',
+                           'hand_manipulation_suite/assets/*',
+                           'hand_manipulation_suite/Adroit/*',
+                           'hand_manipulation_suite/Adroit/gallery/*',
+                           'hand_manipulation_suite/Adroit/resources/*',
+                           'hand_manipulation_suite/Adroit/resources/meshes/*',
+                           'hand_manipulation_suite/Adroit/resources/textures/*',
+                           ]},
+    include_package_data=True,
 )


### PR DESCRIPTION
Fixes #56 

This copies assets necessary to create AntMaze and the DAPG environments to the site-packages directory when installing with pip.