### PR TITLE
Updates to datasets

### DIFF
--- a/d4rl/__init__.py
+++ b/d4rl/__init__.py
@@ -101,10 +101,6 @@ def qlearning_dataset(env, dataset=None, terminate_on_end=False, **kwargs):
     if 'timeouts' in dataset:
         use_timeouts = True
 
-    obs_shape = (N-1,)+ dataset['observations'][0].shape
-    observations_ = np.zeros(obs_shape, dtype=np.float32)
-    next_observations_ = np.zeros(obs_shape, dtype=np.float32)
-
     episode_step = 0
     for i in range(N-1):
         obs = dataset['observations'][i].astype(np.float32)
@@ -124,21 +120,17 @@ def qlearning_dataset(env, dataset=None, terminate_on_end=False, **kwargs):
         if done_bool or final_timestep:
             episode_step = 0
 
-        #obs_.append(obs)
-        #next_obs_.append(new_obs)
-        observations_[i] = obs
-        next_observations_[i] = new_obs
+        obs_.append(obs)
+        next_obs_.append(new_obs)
         action_.append(action)
         reward_.append(reward)
         done_.append(done_bool)
         episode_step += 1
 
     return {
-        #'observations': np.array(obs_),
-        'observations': observations_,
+        'observations': np.array(obs_),
         'actions': np.array(action_),
-        #'next_observations': np.array(next_obs_),
-        'next_observations': next_observations_,
+        'next_observations': np.array(next_obs_),
         'rewards': np.array(reward_),
         'terminals': np.array(done_),
     }

--- a/d4rl/gym_mujoco/__init__.py
+++ b/d4rl/gym_mujoco/__init__.py
@@ -1,5 +1,22 @@
 from gym.envs.registration import register
 from d4rl.gym_mujoco import gym_envs
+from d4rl import infos
+
+# V1 envs
+for agent in ['hopper', 'halfcheetah', 'ant', 'walker2d']:
+    for dataset in ['random', 'medium', 'expert', 'medium-expert', 'medium-replay', 'full-replay']:
+        env_name = '%s-%s-v1' % (agent, dataset)
+        register(
+            id=env_name,
+            entry_point='d4rl.gym_mujoco.gym_envs:get_%s_env' % agent.replace('halfcheetah', 'cheetah').replace('walker2d', 'walker'),
+            max_episode_steps=1000,
+            kwargs={
+                'ref_min_score': infos.REF_MIN_SCORE[env_name],
+                'ref_max_score': infos.REF_MAX_SCORE[env_name],
+                'dataset_url': infos.DATASET_URLS[env_name]
+            }
+        )
+
 
 HOPPER_RANDOM_SCORE = -20.272305
 HALFCHEETAH_RANDOM_SCORE = -280.178953

--- a/d4rl/hand_manipulation_suite/__init__.py
+++ b/d4rl/hand_manipulation_suite/__init__.py
@@ -4,6 +4,24 @@ from d4rl.hand_manipulation_suite.door_v0 import DoorEnvV0
 from d4rl.hand_manipulation_suite.hammer_v0 import HammerEnvV0
 from d4rl.hand_manipulation_suite.pen_v0 import PenEnvV0
 from d4rl.hand_manipulation_suite.relocate_v0 import RelocateEnvV0
+from d4rl import infos
+
+# V1 envs
+MAX_STEPS = {'hammer': 200, 'relocate': 200, 'door': 200, 'pen': 100}
+ENV_MAPPING = {'hammer': 'HammerEnvV0', 'relocate': 'RelocateEnvV0', 'door': 'DoorEnvV0', 'pen': 'PenEnvV0'}
+for agent in ['hammer', 'pen', 'relocate', 'door']:
+    for dataset in ['human', 'expert', 'cloned']:
+        env_name = '%s-%s-v1' % (agent, dataset)
+        register(
+            id=env_name,
+            entry_point='d4rl.hand_manipulation_suite:' + ENV_MAPPING[agent],
+            max_episode_steps=MAX_STEPS[agent],
+            kwargs={
+                'ref_min_score': infos.REF_MIN_SCORE[env_name],
+                'ref_max_score': infos.REF_MAX_SCORE[env_name],
+                'dataset_url': infos.DATASET_URLS[env_name]
+            }
+        )
 
 DOOR_RANDOM_SCORE = -56.512833
 DOOR_EXPERT_SCORE = 2880.5693087298737

--- a/d4rl/infos.py
+++ b/d4rl/infos.py
@@ -96,6 +96,7 @@ DATASET_URLS = {
     'bullet-maze2d-large-v0': 'http://rail.eecs.berkeley.edu/datasets/offline_rl/bullet/bullet-maze2d-large-sparse.hdf5',
 }
 
+
 REF_MIN_SCORE = {
     'maze2d-open-v0' : 0.01 ,
     'maze2d-umaze-v1' : 23.85 ,
@@ -134,6 +135,11 @@ REF_MIN_SCORE = {
     'hopper-expert-v0' : -20.272305 ,
     'hopper-medium-replay-v0' : -20.272305 ,
     'hopper-medium-expert-v0' : -20.272305 ,
+    'ant-random-v0' : -325.6,
+    'ant-medium-v0' : -325.6,
+    'ant-expert-v0' : -325.6,
+    'ant-medium-replay-v0' : -325.6,
+    'ant-medium-expert-v0' : -325.6,
     'antmaze-umaze-v0' : 0.0 ,
     'antmaze-umaze-diverse-v0' : 0.0 ,
     'antmaze-medium-play-v0' : 0.0 ,
@@ -213,6 +219,11 @@ REF_MAX_SCORE = {
     'hopper-expert-v0' : 3234.3 ,
     'hopper-medium-replay-v0' : 3234.3 ,
     'hopper-medium-expert-v0' : 3234.3 ,
+    'ant-random-v0' : 3879.7,
+    'ant-medium-v0' : 3879.7,
+    'ant-expert-v0' : 3879.7,
+    'ant-medium-replay-v0' : 3879.7,
+    'ant-medium-expert-v0' : 3879.7,
     'antmaze-umaze-v0' : 1.0 ,
     'antmaze-umaze-diverse-v0' : 1.0 ,
     'antmaze-medium-play-v0' : 1.0 ,
@@ -253,3 +264,22 @@ REF_MAX_SCORE = {
     'bullet-maze2d-medium-v0': 238.05,
     'bullet-maze2d-large-v0': 285.92,
 }
+
+
+#Gym-MuJoCo V1 envs
+for env in ['halfcheetah', 'hopper', 'walker2d', 'ant']:
+    for dset in ['random', 'medium', 'expert', 'medium-replay', 'full-replay', 'medium-expert']:
+        dset_name = env+'_'+dset.replace('-', '_')+'-v1'
+        env_name = dset_name.replace('_', '-')
+        DATASET_URLS[env_name] = 'http://rail.eecs.berkeley.edu/datasets/offline_rl/gym_mujoco_v1/%s.hdf5' % dset_name
+        REF_MIN_SCORE[env_name] = REF_MIN_SCORE[env+'-random-v0']
+        REF_MAX_SCORE[env_name] = REF_MAX_SCORE[env+'-random-v0']
+
+#Adroit v1 envs
+for env in ['hammer', 'pen', 'relocate', 'door']:
+    for dset in ['human', 'expert', 'cloned']:
+        env_name = env+'-'+dset+'-v1'
+        DATASET_URLS[env_name] = 'http://rail.eecs.berkeley.edu/datasets/offline_rl/hand_dapg_v1/%s.hdf5' % env_name
+        REF_MIN_SCORE[env_name] = REF_MIN_SCORE[env+'-human-v0']
+        REF_MAX_SCORE[env_name] = REF_MAX_SCORE[env+'-human-v0']
+

--- a/scripts/check_envs.py
+++ b/scripts/check_envs.py
@@ -5,22 +5,17 @@ import gym
 import d4rl
 import numpy as np
 
-ENVS = [
-    'halfcheetah-random-v0',
-    'halfcheetah-medium-v0',
-    'halfcheetah-expert-v0',
-    'halfcheetah-mixed-v0',
-    'halfcheetah-medium-expert-v0',
-    'walker2d-random-v0',
-    'walker2d-medium-v0',
-    'walker2d-expert-v0',
-    'walker2d-mixed-v0',
-    'walker2d-medium-expert-v0',
-    'hopper-random-v0',
-    'hopper-medium-v0',
-    'hopper-expert-v0',
-    'hopper-mixed-v0',
-    'hopper-medium-expert-v0',
+ENVS = []
+
+for agent in ['halfcheetah', 'hopper', 'walker2d', 'ant']:
+    for dataset in ['random', 'medium', 'expert', 'medium-replay', 'full-replay', 'medium-expert']:
+        ENVS.append(agent+'-'+dataset+'-v1')
+
+for agent in ['door', 'pen', 'relocate', 'hammer']:
+    for dataset in ['expert', 'cloned', 'human']:
+        ENVS.append(agent+'-'+dataset+'-v1')
+
+ENVS.extend([
     'maze2d-open-v0',
     'maze2d-umaze-v1',
     'maze2d-medium-v1',
@@ -52,14 +47,15 @@ ENVS = [
     'mini-kitchen-microwave-kettle-light-slider-v0',
     'kitchen-microwave-kettle-light-slider-v0',
     'kitchen-microwave-kettle-bottomburner-light-v0',
-]
+])
 
 if __name__ == '__main__':
     for env_name in ENVS:
         print('Checking', env_name)
         try:
             env = gym.make(env_name)
-        except:
+        except Exception as e:
+            print(e)
             continue
         dset = env.get_dataset()
         print('\t Max episode steps:', env._max_episode_steps)
@@ -73,6 +69,7 @@ if __name__ == '__main__':
         assert dset['actions'].shape[0] == N, 'Action number does not match (%d vs %d)' % (dset['actions'].shape[0], N)
         assert dset['rewards'].shape[0] == N, 'Reward number does not match (%d vs %d)' % (dset['rewards'].shape[0], N)
         assert dset['terminals'].shape[0] == N, 'Terminals number does not match (%d vs %d)' % (dset['terminals'].shape[0], N)
+        orig_terminals = np.sum(dset['terminals'])
         print('\t num terminals: %d' % np.sum(dset['terminals']))
 
         env.reset()
@@ -92,3 +89,4 @@ if __name__ == '__main__':
         assert dset['rewards'].shape[0] == N, 'Reward number does not match (%d vs %d)' % (dset['rewards'].shape[0], N)
         assert dset['terminals'].shape[0] == N, 'Terminals number does not match (%d vs %d)' % (dset['terminals'].shape[0], N)
         print('\t num terminals: %d' % np.sum(dset['terminals']))
+        assert orig_terminals == np.sum(dset['terminals']), 'Qlearining terminals doesnt match original terminals'

--- a/scripts/hand_dapg_combined.py
+++ b/scripts/hand_dapg_combined.py
@@ -17,32 +17,54 @@ def get_keys(h5file):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='')
     parser.add_argument('--env_name', type=str, default='pen', help='Env name')
+    parser.add_argument('--bc', type=str, help='BC hdf5 dataset')
+    parser.add_argument('--human', type=str, help='Human demos hdf5 dataset')
     args = parser.parse_args()
 
     env = gym.make('%s-v0' % args.env_name)
-    human_dataset = gym.make('%s-human-v0' % args.env_name).get_dataset()
-    bc_dataset = gym.make('%s-demos-v0' % args.env_name).get_dataset()
+    human_dataset = h5py.File(args.human, 'r')
+    bc_dataset = h5py.File(args.bc, 'r')
     N = env._max_episode_steps * 5000
+
+    # search for nearest terminal after the halfway mark
     halfN = N // 2
+    terms = bc_dataset['terminals'][:]
+    tos = bc_dataset['timeouts'][:]
+    last_term = 0
+    for i in range(halfN, N):
+        if terms[i] or tos[i]:
+            last_term = i
+            break
+    halfN = last_term + 1
 
-    aug_dataset = h5py.File('%s-demos-v0-bc-combined.hdf5' % args.env_name, 'w')
-    for k in human_dataset:
-        human_data = human_dataset[k]
-        bc_data = bc_dataset[k][:halfN]
-        print(k, human_data.shape, bc_data.shape)
-        N_tile = int(halfN / human_data.shape[0]) + 1
-        if len(human_data.shape) == 1:
-            human_data = np.tile(human_data, [N_tile])[:halfN]
-        elif len(human_data.shape) == 2:
-            human_data = np.tile(human_data, [N_tile, 1])[:halfN]
+    remaining_N = N - halfN
+
+    aug_dataset = h5py.File('%s-cloned-v1.hdf5' % args.env_name, 'w')
+    for k in get_keys(bc_dataset):
+        if 'metadata' not in k:
+            human_data = human_dataset[k][:]
+            bc_data = bc_dataset[k][:halfN]
+            print(k, human_data.shape, bc_data.shape)
+            N_tile = int(halfN / human_data.shape[0]) + 1
+            if len(human_data.shape) == 1:
+                human_data = np.tile(human_data, [N_tile])[:remaining_N]
+            elif len(human_data.shape) == 2:
+                human_data = np.tile(human_data, [N_tile, 1])[:remaining_N]
+            else:
+                raise NotImplementedError()
+
+            # clone demo_data
+            aug_data = np.concatenate([bc_data, human_data], axis=0)
+            assert aug_data.shape[1:] == bc_data.shape[1:]
+            assert aug_data.shape[1:] == human_data.shape[1:]
+
+            print('\t',human_data.shape, bc_data.shape, '->',aug_data.shape)
+            aug_dataset.create_dataset(k, data=aug_data, compression='gzip')
         else:
-            raise NotImplementedError()
-
-        # clone demo_data
-        aug_data = np.concatenate([human_data, bc_data], axis=0)
-        assert aug_data.shape[1:] == bc_data.shape[1:]
-        assert aug_data.shape[1:] == human_data.shape[1:]
-
-        print('\t',human_data.shape, bc_data.shape, '->',aug_data.shape)
-        aug_dataset.create_dataset(k, data=aug_data, compression='gzip')
+            shape = bc_dataset[k].shape
+            print('metadata:', k, shape)
+            if len(shape) == 0:
+                aug_dataset[k] = bc_dataset[k][()]
+            else:
+                aug_dataset[k] = bc_dataset[k][:]
 


### PR DESCRIPTION
Incorporates updates for datasets to Gym-MuJoCo and Adroit tasks, and bumps the versions to v1.
- Full state information (qpos, qvel, and assorted environment-specific information).
- Better metadata, including action log-probabilities and policy weights.
- Fixes inconsistencies with terminals in the existing datasets, and some Gym-MuJoCo tasks having path lengths != 1000.