### PR TITLE
Fixed missing variable bug in reverse_normalized_score

### DIFF
--- a/d4rl/__init__.py
+++ b/d4rl/__init__.py
@@ -50,10 +50,9 @@ except ImportError as e:
         print(_ERROR_MESSAGE % 'GymBullet', file=sys.stderr)
         print(e, file=sys.stderr)
 
-def reverse_normalized_score(env_name, normalized_score):
+def reverse_normalized_score(env_name, score):
     ref_min_score = d4rl.infos.REF_MIN_SCORE[env_name]
     ref_max_score = d4rl.infos.REF_MAX_SCORE[env_name]
-    # return (score - ref_min_score) / (ref_max_score - ref_min_score)
     return (score * (ref_max_score - ref_min_score)) + ref_min_score
 
 def get_normalized_score(env_name, score):


### PR DESCRIPTION
The `reverse_normalized_score` didn't work because the code assumed that the score variable was named `score` while it was named  `normalized_score`.
Fixes issue #83 