### PR TITLE
* fix installation on macOS -- dm_control can not install from git on

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,19 @@
 from distutils.core import setup
+from platform import platform
+
 from setuptools import find_packages
 
 setup(
     name='d4rl',
     version='1.1',
-    install_requires=['gym', 
-                      'numpy', 
-                      'mujoco_py', 
+    install_requires=['gym',
+                      'numpy',
+                      'mujoco_py',
                       'pybullet',
-                      'h5py', 
-                      'termcolor', # adept_envs dependency
+                      'h5py',
+                      'termcolor',  # adept_envs dependency
                       'click',  # adept_envs dependency
+                      'dm_control' if 'macOS' in platform() else
                       'dm_control @ git+git://github.com/deepmind/dm_control@master#egg=dm_control',
                       'mjrl @ git+git://github.com/aravindr93/mjrl@master#egg=mjrl'],
     packages=find_packages(),


### PR DESCRIPTION
Installation fails on macOSX, because the `dm_control` entry installs from git. This is known to fail in OSX because of this issue: https://github.com/deepmind/dm_control/issues/6

Installing from PyPI works.

**Change List**
* fix installation on macOS -- dm_control can not install from git on  OSX.
* ignore IDE .idea files