### PR TITLE
20210616 ge h4py context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/d4rl/offline_env.py
+++ b/d4rl/offline_env.py
@@ -1,20 +1,27 @@
 import os
+import urllib.request
+
 import gym
 import h5py
-import urllib.request
+from tqdm import tqdm
+
 
 def set_dataset_path(path):
     global DATASET_PATH
     DATASET_PATH = path
     os.makedirs(path, exist_ok=True)
 
+
 set_dataset_path(os.environ.get('D4RL_DATASET_DIR', os.path.expanduser('~/.d4rl/datasets')))
+
 
 def get_keys(h5file):
     keys = []
+
     def visitor(name, item):
         if isinstance(item, h5py.Dataset):
             keys.append(name)
+
     h5file.visititems(visitor)
     return keys
 
@@ -35,7 +42,6 @@ def download_dataset_from_url(dataset_url):
     return dataset_filepath
 
 
-
 class OfflineEnv(gym.Env):
     """
     Base class for offline RL envs.
@@ -45,6 +51,7 @@ class OfflineEnv(gym.Env):
         ref_max_score: Maximum score (for score normalization)
         ref_min_score: Minimum score (for score normalization)
     """
+
     def __init__(self, dataset_url=None, ref_max_score=None, ref_min_score=None, **kwargs):
         super(OfflineEnv, self).__init__(**kwargs)
         self.dataset_url = self._dataset_url = dataset_url
@@ -66,15 +73,13 @@ class OfflineEnv(gym.Env):
                 raise ValueError("Offline env not configured with a dataset URL.")
             h5path = download_dataset_from_url(self.dataset_url)
 
-        dataset_file = h5py.File(h5path, 'r')
         data_dict = {}
-        for k in get_keys(dataset_file):
-            try:
-                # first try loading as an array
-                data_dict[k] = dataset_file[k][:]
-            except ValueError as e: # try loading as a scalar
-                data_dict[k] = dataset_file[k][()]
-        dataset_file.close()
+        with h5py.File(h5path, 'r') as dataset_file:
+            for k in tqdm(get_keys(dataset_file), desc="load datafile"):
+                try:  # first try loading as an array
+                    data_dict[k] = dataset_file[k][:]
+                except ValueError as e:  # try loading as a scalar
+                    data_dict[k] = dataset_file[k][()]
 
         # Run a few quick sanity checks
         for key in ['observations', 'actions', 'rewards', 'terminals']:
@@ -82,17 +87,20 @@ class OfflineEnv(gym.Env):
         N_samples = data_dict['observations'].shape[0]
         if self.observation_space.shape is not None:
             assert data_dict['observations'].shape[1:] == self.observation_space.shape, \
-                    'Observation shape does not match env: %s vs %s' % (str(data_dict['observations'].shape[1:]), str(self.observation_space.shape))
+                'Observation shape does not match env: %s vs %s' % (
+                    str(data_dict['observations'].shape[1:]), str(self.observation_space.shape))
         assert data_dict['actions'].shape[1:] == self.action_space.shape, \
-                    'Action shape does not match env: %s vs %s' % (str(data_dict['actions'].shape[1:]), str(self.action_space.shape))
+            'Action shape does not match env: %s vs %s' % (
+                str(data_dict['actions'].shape[1:]), str(self.action_space.shape))
         if data_dict['rewards'].shape == (N_samples, 1):
-            data_dict['rewards'] = data_dict['rewards'][:,0]
-        assert data_dict['rewards'].shape == (N_samples,), 'Reward has wrong shape: %s' % (str(data_dict['rewards'].shape))
+            data_dict['rewards'] = data_dict['rewards'][:, 0]
+        assert data_dict['rewards'].shape == (N_samples,), 'Reward has wrong shape: %s' % (
+            str(data_dict['rewards'].shape))
         if data_dict['terminals'].shape == (N_samples, 1):
-            data_dict['terminals'] = data_dict['terminals'][:,0]
-        assert data_dict['terminals'].shape == (N_samples,), 'Terminals has wrong shape: %s' % (str(data_dict['rewards'].shape))
+            data_dict['terminals'] = data_dict['terminals'][:, 0]
+        assert data_dict['terminals'].shape == (N_samples,), 'Terminals has wrong shape: %s' % (
+            str(data_dict['rewards'].shape))
         return data_dict
-
 
     def get_dataset_chunk(self, chunk_id, h5path=None):
         """
@@ -127,10 +135,10 @@ class OfflineEnvWrapper(gym.Wrapper, OfflineEnv):
     """
     Wrapper class for offline RL envs.
     """
+
     def __init__(self, env, **kwargs):
         gym.Wrapper.__init__(self, env)
         OfflineEnv.__init__(self, **kwargs)
 
     def reset(self):
         return self.env.reset()
-

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,19 @@
 from distutils.core import setup
+from platform import platform
+
 from setuptools import find_packages
 
 setup(
     name='d4rl',
     version='1.1',
-    install_requires=['gym', 
-                      'numpy', 
-                      'mujoco_py', 
+    install_requires=['gym',
+                      'numpy',
+                      'mujoco_py',
                       'pybullet',
-                      'h5py', 
-                      'termcolor', # adept_envs dependency
+                      'h5py',
+                      'termcolor',  # adept_envs dependency
                       'click',  # adept_envs dependency
+                      'dm_control' if 'macOS' in platform() else
                       'dm_control @ git+git://github.com/deepmind/dm_control@master#egg=dm_control',
                       'mjrl @ git+git://github.com/aravindr93/mjrl@master#egg=mjrl'],
     packages=find_packages(),


### PR DESCRIPTION
This change uses the h5py.File() object as a context to automatically close the file. This is useful during debug, when the program can exit before calling `file.close()`. 

This change list contains commits in #102 -- I can remove those if this seem interesting to you. 
The white spaces and reordering of import come from PEP8 linting -- I can remove those too if it appears unecessary.

@justinjfu