### PR TITLE
Fix master-vs-main inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ pip install -e .
 
 Or, alternatively:
 ```
-pip install git+https://github.com/rail-berkeley/d4rl@master#egg=d4rl
+pip install git+https://github.com/rail-berkeley/d4rl@main#egg=d4rl
 ```
 
 The control environments require MuJoCo as a dependency. You may need to obtain a [license](https://www.roboti.us/license.html) and follow the setup instructions for mujoco_py. This mostly involves copying the key to your MuJoCo installation folder.

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
                       'click',  # adept_envs dependency
                       'dm_control' if 'macOS' in platform() else
                       'dm_control @ git+git://github.com/deepmind/dm_control@main#egg=dm_control',
-                      'mjrl @ git+git://github.com/aravindr93/mjrl@main#egg=mjrl'
+                      'mjrl @ git+git://github.com/aravindr93/mjrl@aster#egg=mjrl'
                       ],
     packages=find_packages(),
     package_data={'d4rl': ['locomotion/assets/*',

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,9 @@ setup(
                       'termcolor',  # adept_envs dependency
                       'click',  # adept_envs dependency
                       'dm_control' if 'macOS' in platform() else
-                      'dm_control @ git+git://github.com/deepmind/dm_control@master#egg=dm_control',
-                      'mjrl @ git+git://github.com/aravindr93/mjrl@master#egg=mjrl'],
+                      'dm_control @ git+git://github.com/deepmind/dm_control@main#egg=dm_control',
+                      'mjrl @ git+git://github.com/aravindr93/mjrl@main#egg=mjrl'
+                      ],
     packages=find_packages(),
     package_data={'d4rl': ['locomotion/assets/*',
                            'hand_manipulation_suite/assets/*',


### PR DESCRIPTION
Fixed the wrong `master` references in the dependencies to the updated `main` ones. Otherwise the install is failing.

It will fix the [Issue 109](https://github.com/rail-berkeley/d4rl/issues/109) that was also created by me, a couple of days ago.