### PR TITLE
Fix the bug that Maze2D and AntMaze cannot be used in windows

### DIFF
--- a/d4rl/locomotion/maze_env.py
+++ b/d4rl/locomotion/maze_env.py
@@ -198,8 +198,9 @@ class MazeEnv(gym.Env):
     torso = tree.find(".//body[@name='torso']")
     geoms = torso.findall(".//geom")
 
-    _, file_path = tempfile.mkstemp(text=True, suffix='.xml')
+    fd, file_path = tempfile.mkstemp(text=True, suffix='.xml')
     tree.write(file_path)
+    os.close(fd)
 
     self.LOCOMOTION_ENV.__init__(self, *args, file_path=file_path, non_zero_reset=non_zero_reset, reward_type=reward_type, **kwargs)
 

--- a/d4rl/pointmaze/dynamic_mjc.py
+++ b/d4rl/pointmaze/dynamic_mjc.py
@@ -51,9 +51,10 @@ class MJCModel(object):
         with model.asfile() as f:
             print f.read()  # prints a dump of the model
         """
-        with tempfile.NamedTemporaryFile(mode='w+', suffix='.xml', delete=True) as f:
+        with tempfile.NamedTemporaryFile(mode='w+', suffix='.xml', delete=False) as f:
             self.root.write(f)
             f.seek(0)
+            f.close()
             yield f
 
     def open(self):


### PR DESCRIPTION
Hi, thank you very much for providing such a good open source dataset, but I am having the same problem as #98 when running Maze2D and AntMaze on windows.

The method "mujoco_py.load_model_from_path(fullpath)" can't load the file because it was opened but not closed when the temporary file was generated. So I closed the file before calling this method, and it worked.